### PR TITLE
cmd: add `lscpuaff` tool

### DIFF
--- a/cmd/lscpuaff/main.go
+++ b/cmd/lscpuaff/main.go
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/openshift-kni/debug-tools/pkg/procs"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] [cpulist]\n", filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+	var procfsRoot = flag.StringP("procfs", "P", "/proc", "procfs mount point to use.")
+	var pidIdent = flag.StringP("pid", "p", "", "monitor only threads belonging to this pid (default is all).")
+	flag.Parse()
+
+	isolCpuList := "0-65535" // "everything"
+	args := flag.Args()
+	if len(args) == 1 {
+		isolCpuList = args[0]
+	}
+
+	isolCpus, err := cpuset.Parse(isolCpuList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing %q: %v", isolCpuList, err)
+		os.Exit(1)
+	}
+
+	if *pidIdent != "" {
+		pid, err := strconv.Atoi(*pidIdent)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error parsing %q: %v", *pidIdent, err)
+			os.Exit(2)
+		}
+		procInfo, err := procs.FromPID(*procfsRoot, pid)
+		for tid, tidInfo := range procInfo.TIDs {
+			threadCpus := cpuset.NewCPUSet(tidInfo.Affinity...)
+
+			cpus := threadCpus.Intersection(isolCpus)
+			if cpus.Size() != 0 {
+				fmt.Printf("PID %6d TID %6d can run on %v\n", pid, tid, cpus.ToSlice())
+			}
+		}
+	}
+
+	procInfos, err := procs.All(*procfsRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error getting process infos from %q: %v", *procfsRoot, err)
+		os.Exit(1)
+	}
+
+	pids := make([]int, len(procInfos))
+	for pid := range procInfos {
+		pids = append(pids, pid)
+	}
+	sort.Ints(pids)
+	for _, pid := range pids {
+		procInfo := procInfos[pid]
+
+		tids := make([]int, len(procInfo.TIDs))
+		for tid := range procInfo.TIDs {
+			tids = append(tids, tid)
+		}
+		sort.Ints(tids)
+
+		for _, tid := range tids {
+			tidInfo := procInfo.TIDs[tid]
+			threadCpus := cpuset.NewCPUSet(tidInfo.Affinity...)
+
+			cpus := threadCpus.Intersection(isolCpus)
+			if cpus.Size() != 0 {
+				fmt.Printf("PID %6d (%-32s) TID %6d (%-16s) can run on %v\n", pid, procInfo.Name, tid, tidInfo.Name, cpus.ToSlice())
+			}
+		}
+	}
+}

--- a/pkg/procs/info.go
+++ b/pkg/procs/info.go
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package procs
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+)
+
+type TIDInfo struct {
+	Tid      int
+	Name     string
+	Affinity []int
+}
+
+type PIDInfo struct {
+	Pid  int
+	Name string
+	TIDs map[int]TIDInfo
+}
+
+func All(procfsRoot string) (map[int]PIDInfo, error) {
+	infos := make(map[int]PIDInfo)
+	pidEntries, err := ioutil.ReadDir(procfsRoot)
+	if err != nil {
+		return infos, err
+	}
+
+	for _, pidEntry := range pidEntries {
+		if !pidEntry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(pidEntry.Name())
+		if err != nil {
+			// doesn't look like a pid
+			continue
+		}
+
+		pidInfo, err := FromPID(procfsRoot, pid)
+		if err != nil {
+			// TODO log
+			continue
+		}
+
+		infos[pid] = pidInfo
+	}
+	return infos, nil
+}
+
+func FromPID(procfsRoot string, pid int) (PIDInfo, error) {
+	pidInfo := PIDInfo{
+		Pid:  pid,
+		TIDs: make(map[int]TIDInfo),
+	}
+
+	if procName, err := readProcessName(procfsRoot, pid); err == nil {
+		// failures not critical
+		pidInfo.Name = basename(procName)
+	}
+
+	tasksDir := filepath.Join(procfsRoot, fmt.Sprintf("%d", pid), "task")
+	tidEntries, err := ioutil.ReadDir(tasksDir)
+	if err != nil {
+		// TODO log
+		return pidInfo, err
+	}
+
+	for _, tidEntry := range tidEntries {
+		// TODO: use x/sys/unix schedGetAffinity?
+		info, err := parseProcStatus(filepath.Join(tasksDir, tidEntry.Name(), "status"))
+		if err != nil {
+			continue
+		}
+		pidInfo.TIDs[info.Tid] = info
+	}
+
+	return pidInfo, nil
+}
+
+func parseProcStatus(path string) (TIDInfo, error) {
+	info := TIDInfo{}
+	file, err := os.Open(path)
+	if err != nil {
+		return info, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Name:") {
+			items := strings.SplitN(line, ":", 2)
+			info.Name = strings.TrimSpace(items[1])
+		}
+		if strings.HasPrefix(line, "Pid:") {
+			items := strings.SplitN(line, ":", 2)
+			pid, err := strconv.Atoi(strings.TrimSpace(items[1]))
+			if err != nil {
+				return info, err
+			}
+			// yep, the field is called "pid" even if we are scaning /proc/XXX/task/YYY/status
+			info.Tid = pid
+		}
+		if strings.HasPrefix(line, "Cpus_allowed_list:") {
+			items := strings.SplitN(line, ":", 2)
+			cpuIDs, err := cpuset.Parse(strings.TrimSpace(items[1]))
+			if err != nil {
+				return info, err
+			}
+			info.Affinity = cpuIDs.ToSlice()
+		}
+	}
+
+	return info, scanner.Err()
+}
+
+func readProcessName(procfsRoot string, pid int) (string, error) {
+	data, err := ioutil.ReadFile(filepath.Join(procfsRoot, fmt.Sprintf("%d", pid), "cmdline"))
+	if err != nil {
+		return "", err
+	}
+	cmdline := string(data)
+	// workaround
+	if off := strings.Index(cmdline, " "); off > 0 {
+		return cmdline[:off], nil
+	}
+	if off := strings.Index(cmdline, "\x00"); off > 0 {
+		return cmdline[:off], nil
+	}
+	return cmdline, nil
+}
+
+func basename(path string) string {
+	name := filepath.Base(path)
+	if name == "." {
+		return ""
+	}
+	return name
+}


### PR DESCRIPTION
`lscpuaff` scans all the threads in the system and check their
affinity mask against the provided one, allowing to easily
check for collisions.

Signed-off-by: Francesco Romani <fromani@redhat.com>