### PR TITLE
knit: avoid global options

### DIFF
--- a/cmd/knit/cmd/cpuaff.go
+++ b/cmd/knit/cmd/cpuaff.go
@@ -31,13 +31,13 @@ type cpuAffOptions struct {
 	pidIdent string
 }
 
-func newCPUAffinityCommand() *cobra.Command {
+func newCPUAffinityCommand(knitOpts *knitOptions) *cobra.Command {
 	opts := &cpuAffOptions{}
 	cpuAff := &cobra.Command{
 		Use:   "cpuaff",
 		Short: "show cpu thread affinities",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return showCPUAffinity(cmd, opts, args)
+			return showCPUAffinity(cmd, knitOpts, opts, args)
 		},
 		Args: cobra.NoArgs,
 	}
@@ -45,7 +45,7 @@ func newCPUAffinityCommand() *cobra.Command {
 	return cpuAff
 }
 
-func showCPUAffinity(cmd *cobra.Command, opts *cpuAffOptions, args []string) error {
+func showCPUAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *cpuAffOptions, args []string) error {
 	ph := procs.New(knitOpts.log, knitOpts.procFSRoot)
 
 	if opts.pidIdent != "" {

--- a/cmd/knit/cmd/root.go
+++ b/cmd/knit/cmd/root.go
@@ -36,11 +36,9 @@ type knitOptions struct {
 	log   *log.Logger
 }
 
-var knitOpts knitOptions
-
 // NewRootCommand returns entrypoint command to interact with all other commands
 func NewRootCommand() *cobra.Command {
-
+	knitOpts := &knitOptions{}
 	root := &cobra.Command{
 		Use:   "knit",
 		Short: "knit allows to check system settings for low-latency workload",
@@ -73,8 +71,8 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().BoolVarP(&knitOpts.debug, "debug", "D", false, "enable debug log")
 
 	root.AddCommand(
-		newCPUAffinityCommand(),
-		newIRQAffinityCommand(),
+		newCPUAffinityCommand(knitOpts),
+		newIRQAffinityCommand(knitOpts),
 	)
 
 	return root


### PR DESCRIPTION
Let's not use global variables if we can help it.
Internal cleanup only, no changes in behaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>