### PR TITLE
cmd: add JSON output

### DIFF
--- a/cmd/knit/cmd/root.go
+++ b/cmd/knit/cmd/root.go
@@ -32,8 +32,9 @@ type knitOptions struct {
 	procFSRoot string
 	sysFSRoot  string
 
-	debug bool
-	log   *log.Logger
+	jsonOutput bool
+	debug      bool
+	log        *log.Logger
 }
 
 // NewRootCommand returns entrypoint command to interact with all other commands
@@ -69,6 +70,7 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().StringVarP(&knitOpts.procFSRoot, "procfs", "P", "/proc", "procfs root")
 	root.PersistentFlags().StringVarP(&knitOpts.sysFSRoot, "sysfs", "S", "/sys", "sysfs root")
 	root.PersistentFlags().BoolVarP(&knitOpts.debug, "debug", "D", false, "enable debug log")
+	root.PersistentFlags().BoolVarP(&knitOpts.jsonOutput, "json", "J", false, "output as JSON")
 
 	root.AddCommand(
 		newCPUAffinityCommand(knitOpts),

--- a/pkg/procs/info.go
+++ b/pkg/procs/info.go
@@ -30,15 +30,15 @@ import (
 )
 
 type TIDInfo struct {
-	Tid      int
-	Name     string
-	Affinity []int
+	Tid      int    `json:"tid"`
+	Name     string `json:"name"`
+	Affinity []int  `json:"affinity"`
 }
 
 type PIDInfo struct {
-	Pid  int
-	Name string
-	TIDs map[int]TIDInfo
+	Pid  int             `json:"pid"`
+	Name string          `json:"name"`
+	TIDs map[int]TIDInfo `json:"threads"`
 }
 
 type Handler struct {


### PR DESCRIPTION
JSON output is easier to parse for machines,
so it's useful to support it alongside custom text output.

Signed-off-by: Francesco Romani <fromani@redhat.com>