### PR TITLE
knit: move commands into pkg

### DIFF
--- a/cmd/knit/main.go
+++ b/cmd/knit/main.go
@@ -20,16 +20,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/openshift-kni/debug-tools/cmd/knit/cmd"
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
 )
 
-func expectNoError(err error) {
-	if err != nil {
+func main() {
+	if err := cmd.NewRootCommand().Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-}
-
-func main() {
-	expectNoError(cmd.NewRootCommand().Execute())
 }

--- a/pkg/knit/cmd/cpuaff.go
+++ b/pkg/knit/cmd/cpuaff.go
@@ -33,7 +33,7 @@ type cpuAffOptions struct {
 	pidIdent string
 }
 
-func newCPUAffinityCommand(knitOpts *knitOptions) *cobra.Command {
+func NewCPUAffinityCommand(knitOpts *KnitOptions) *cobra.Command {
 	opts := &cpuAffOptions{}
 	cpuAff := &cobra.Command{
 		Use:   "cpuaff",
@@ -63,8 +63,8 @@ func (ru runnable) String() string {
 	return fmt.Sprintf("PID %6d (%-32s) TID %6d (%-16s) can run on %v", ru.PID, ru.ProcessName, ru.TID, ru.ThreadName, ru.CPUAffinity)
 }
 
-func showCPUAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *cpuAffOptions, args []string) error {
-	ph := procs.New(knitOpts.log, knitOpts.procFSRoot)
+func showCPUAffinity(cmd *cobra.Command, knitOpts *KnitOptions, opts *cpuAffOptions, args []string) error {
+	ph := procs.New(knitOpts.Log, knitOpts.ProcFSRoot)
 
 	if opts.pidIdent != "" {
 		pid, err := strconv.Atoi(opts.pidIdent)
@@ -75,7 +75,7 @@ func showCPUAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *cpuAffOpti
 		for tid, tidInfo := range procInfo.TIDs {
 			threadCpus := cpuset.NewCPUSet(tidInfo.Affinity...)
 
-			cpus := threadCpus.Intersection(knitOpts.cpus)
+			cpus := threadCpus.Intersection(knitOpts.Cpus)
 			if cpus.Size() != 0 {
 				fmt.Printf("PID %6d TID %6d can run on %v\n", pid, tid, cpus.String())
 			}
@@ -85,7 +85,7 @@ func showCPUAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *cpuAffOpti
 
 	procInfos, err := ph.ListAll()
 	if err != nil {
-		return fmt.Errorf("error getting process infos from %q: %v", knitOpts.procFSRoot, err)
+		return fmt.Errorf("error getting process infos from %q: %v", knitOpts.ProcFSRoot, err)
 	}
 
 	var runnables []runnable
@@ -96,7 +96,7 @@ func showCPUAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *cpuAffOpti
 			tidInfo := procInfo.TIDs[tid]
 
 			threadCpus := cpuset.NewCPUSet(tidInfo.Affinity...)
-			cpus := threadCpus.Intersection(knitOpts.cpus)
+			cpus := threadCpus.Intersection(knitOpts.Cpus)
 			if cpus.Size() == 0 {
 				continue
 			}
@@ -110,7 +110,7 @@ func showCPUAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *cpuAffOpti
 		}
 	}
 
-	if knitOpts.jsonOutput {
+	if knitOpts.JsonOutput {
 		json.NewEncoder(os.Stdout).Encode(runnables)
 	} else {
 		for _, runnable := range runnables {

--- a/pkg/knit/cmd/irqaff.go
+++ b/pkg/knit/cmd/irqaff.go
@@ -34,7 +34,7 @@ type irqAffOptions struct {
 	showEmptySource bool
 }
 
-func newIRQAffinityCommand(knitOpts *knitOptions) *cobra.Command {
+func NewIRQAffinityCommand(knitOpts *KnitOptions) *cobra.Command {
 	opts := &irqAffOptions{}
 	irqAff := &cobra.Command{
 		Use:   "irqaff",
@@ -73,8 +73,8 @@ func (sa softirqAffinity) String() string {
 	return fmt.Sprintf("%8s = %v", sa.SoftIRQ, sa.CPUAffinity)
 }
 
-func showIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAffOptions, args []string) error {
-	ih := irqs.New(knitOpts.log, knitOpts.procFSRoot)
+func showIRQAffinity(cmd *cobra.Command, knitOpts *KnitOptions, opts *irqAffOptions, args []string) error {
+	ih := irqs.New(knitOpts.Log, knitOpts.ProcFSRoot)
 
 	flags := uint(0)
 	if opts.checkEffective {
@@ -83,12 +83,12 @@ func showIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAffOpti
 
 	irqInfos, err := ih.ReadInfo(flags)
 	if err != nil {
-		return fmt.Errorf("error parsing irqs from %q: %v", knitOpts.procFSRoot, err)
+		return fmt.Errorf("error parsing irqs from %q: %v", knitOpts.ProcFSRoot, err)
 	}
 
 	var irqAffinities []irqAffinity
 	for _, irqInfo := range irqInfos {
-		cpus := irqInfo.CPUs.Intersection(knitOpts.cpus)
+		cpus := irqInfo.CPUs.Intersection(knitOpts.Cpus)
 		if cpus.Size() == 0 {
 			continue
 		}
@@ -102,7 +102,7 @@ func showIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAffOpti
 		})
 	}
 
-	if knitOpts.jsonOutput {
+	if knitOpts.JsonOutput {
 		json.NewEncoder(os.Stdout).Encode(irqAffinities)
 	} else {
 		for _, irqAffinity := range irqAffinities {
@@ -112,12 +112,12 @@ func showIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAffOpti
 	return nil
 }
 
-func showSoftIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAffOptions, args []string) error {
-	sh := softirqs.New(knitOpts.log, knitOpts.procFSRoot)
+func showSoftIRQAffinity(cmd *cobra.Command, knitOpts *KnitOptions, opts *irqAffOptions, args []string) error {
+	sh := softirqs.New(knitOpts.Log, knitOpts.ProcFSRoot)
 	info, err := sh.ReadInfo()
 
 	if err != nil {
-		return fmt.Errorf("error parsing softirqs from %q: %v", knitOpts.procFSRoot, err)
+		return fmt.Errorf("error parsing softirqs from %q: %v", knitOpts.ProcFSRoot, err)
 	}
 
 	var softirqAffinities []softirqAffinity
@@ -130,7 +130,7 @@ func showSoftIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAff
 				cb.Add(idx)
 			}
 		}
-		usedCPUs := knitOpts.cpus.Intersection(cb.Result())
+		usedCPUs := knitOpts.Cpus.Intersection(cb.Result())
 
 		softirqAffinities = append(softirqAffinities, softirqAffinity{
 			SoftIRQ:     key,
@@ -138,7 +138,7 @@ func showSoftIRQAffinity(cmd *cobra.Command, knitOpts *knitOptions, opts *irqAff
 		})
 	}
 
-	if knitOpts.jsonOutput {
+	if knitOpts.JsonOutput {
 		json.NewEncoder(os.Stdout).Encode(softirqAffinities)
 	} else {
 		for _, softirqAffinity := range softirqAffinities {

--- a/pkg/knit/cmd/podres.go
+++ b/pkg/knit/cmd/podres.go
@@ -41,7 +41,7 @@ type podResOptions struct {
 	socketPath string
 }
 
-func newPodResourcesCommand(knitOpts *knitOptions) *cobra.Command {
+func NewPodResourcesCommand(knitOpts *KnitOptions) *cobra.Command {
 	opts := &podResOptions{}
 	podRes := &cobra.Command{
 		Use:   "podres",


### PR DESCRIPTION
code movement + trivial rename to move the cobra commands into
a package, to improve reusability.

Signed-off-by: Francesco Romani <fromani@redhat.com>