### PR TITLE
cmd: root: allow to pass factory functions

### DIFF
--- a/pkg/knit/cmd/root.go
+++ b/pkg/knit/cmd/root.go
@@ -41,8 +41,10 @@ func ShowHelp(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+type NewCommandFunc func(ko *KnitOptions) *cobra.Command
+
 // NewRootCommand returns entrypoint command to interact with all other commands
-func NewRootCommand() *cobra.Command {
+func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 	knitOpts := &KnitOptions{}
 
 	root := &cobra.Command{
@@ -82,6 +84,9 @@ func NewRootCommand() *cobra.Command {
 		NewIRQAffinityCommand(knitOpts),
 		NewPodResourcesCommand(knitOpts),
 	)
+	for _, extraCmd := range extraCmds {
+		root.AddCommand(extraCmd(knitOpts))
+	}
 
 	return root
 


### PR DESCRIPTION
The knit RootCommand wants to own KnitOptions, to avoid globals.
Hence, to make it extensible and allow consumers of the package to
add their subcommands, we need to pass to it the factory functions,
so the new commands can easily consume the KnitOptions.

Signed-off-by: Francesco Romani <fromani@redhat.com>