### PR TITLE
cmd: add snapproc command

### DIFF
--- a/pkg/knit/cmd/root.go
+++ b/pkg/knit/cmd/root.go
@@ -83,6 +83,7 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 		NewCPUAffinityCommand(knitOpts),
 		NewIRQAffinityCommand(knitOpts),
 		NewIRQWatchCommand(knitOpts),
+		NewSnapProcCommand(knitOpts),
 		NewWaitCommand(knitOpts),
 	)
 	for _, extraCmd := range extraCmds {

--- a/pkg/knit/cmd/snapproc.go
+++ b/pkg/knit/cmd/snapproc.go
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/jaypipes/ghw/pkg/snapshot"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/debug-tools/pkg/procs"
+)
+
+type snapProcOptions struct {
+	preserve     bool
+	cloneDirPath string
+	output       string
+}
+
+func NewSnapProcCommand(knitOpts *KnitOptions) *cobra.Command {
+	opts := &snapProcOptions{}
+	snapProc := &cobra.Command{
+		Use:   "snapproc",
+		Short: "create snapshot of running processes",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return makeProcSnapshot(cmd, knitOpts, opts, args)
+		},
+		Args: cobra.NoArgs,
+	}
+	snapProc.Flags().BoolVar(&opts.preserve, "preserve", false, "do not remove the scratch directory clone once done.")
+	snapProc.Flags().StringVarP(&opts.cloneDirPath, "clone-path", "c", "", "proc clone path. If not given, generate random name.")
+	snapProc.Flags().StringVarP(&opts.output, "output", "o", "snapproc.tgz", "proc snapshot. Use \"-\" to send on stdout.")
+	return snapProc
+}
+
+func makeProcSnapshot(cmd *cobra.Command, knitOpts *KnitOptions, opts *snapProcOptions, args []string) error {
+	var scratchDir string
+	var err error
+	if opts.cloneDirPath != "" {
+		// if user supplies the path, then the user owns the path. So we intentionally don't remove it once done.
+		scratchDir = opts.cloneDirPath
+	} else {
+		scratchDir, err = ioutil.TempDir("", "kni-snapproc")
+		if err != nil {
+			return err
+		}
+		if opts.preserve {
+			defer fmt.Fprintf(os.Stderr, "preserved scratch directory %q\n", scratchDir)
+		} else {
+			defer os.RemoveAll(scratchDir)
+		}
+	}
+
+	if err = procs.CloneInto(knitOpts.Log, knitOpts.ProcFSRoot, scratchDir); err != nil {
+		return err
+	}
+
+	return snapshot.PackFrom(opts.output, scratchDir)
+}

--- a/pkg/procs/clone.go
+++ b/pkg/procs/clone.go
@@ -1,0 +1,120 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Copyright 2021 Red Hat, Inc.
+ */
+
+package procs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// the proc layout we care about is more volatile than the ghw/snapshot package expects to deal with. So we need extra care.
+func CloneInto(logger *log.Logger, procfsRoot, scratchDir string) error {
+	baseDir := filepath.Join(scratchDir, "proc")
+
+	var err error
+	if err = os.MkdirAll(baseDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	pidEntries, err := ioutil.ReadDir(procfsRoot)
+	if err != nil {
+		return err
+	}
+	for _, pidEntry := range pidEntries {
+		if !pidEntry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(pidEntry.Name())
+		if err != nil {
+			// doesn't look like a pid
+			continue
+		}
+
+		err = CloneEntry(logger, pid, procfsRoot, scratchDir)
+		if err != nil {
+			logger.Printf("cannot clone data for pid %d (skipped): %v", pid, err)
+			continue
+		}
+	}
+	return nil
+}
+
+func CloneEntry(logger *log.Logger, pid int, procfsRoot, scratchDir string) error {
+	entryDir := filepath.Join(procfsRoot, fmt.Sprintf("%d", pid))
+	var err error
+	// keep the file open to (kinda-)lock the entry
+	handle, err := os.Open(filepath.Join(entryDir, "cmdline"))
+	if err != nil {
+		return err
+	}
+	defer handle.Close()
+
+	if err = cloneRunnableData(scratchDir, entryDir, "cmdline", "status"); err != nil {
+		return err
+	}
+
+	taskRoot := filepath.Join(entryDir, "task")
+
+	tidEntries, err := ioutil.ReadDir(taskRoot)
+	if err != nil {
+		return err
+	}
+	for _, tidEntry := range tidEntries {
+		if !tidEntry.IsDir() {
+			continue
+		}
+		tid, err := strconv.Atoi(tidEntry.Name())
+		if err != nil {
+			// doesn't look like a tid
+			continue
+		}
+
+		err = cloneRunnableData(scratchDir, filepath.Join(taskRoot, tidEntry.Name()), "status")
+		if err != nil {
+			logger.Printf("cannot clone data for tid %d (skipped): %v", tid, err)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func cloneRunnableData(scratchDir, baseDir string, items ...string) error {
+	for _, item := range items {
+		if err := os.MkdirAll(filepath.Join(scratchDir, baseDir), os.ModePerm); err != nil {
+			return err
+		}
+
+		path := filepath.Join(baseDir, item)
+		if err := copyFile(path, filepath.Join(scratchDir, path)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(path, targetPath string) error {
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(targetPath, buf, os.ModePerm)
+}

--- a/test/e2e/knit_snapproc_cpulist.go
+++ b/test/e2e/knit_snapproc_cpulist.go
@@ -1,0 +1,74 @@
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/jaypipes/ghw/pkg/snapshot"
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+)
+
+const (
+	snapprocName = "snapproc.tgz"
+)
+
+var _ = g.Describe("knit snapproc tests", func() {
+	var snapPath string
+
+	g.AfterEach(func() {
+		os.Remove(snapprocName)
+		if snapPath != "" {
+			os.RemoveAll(snapPath)
+		}
+	})
+
+	g.Context("With process snapshot", func() {
+		g.It("Should be readable by cpulist", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "knit"),
+				"snapproc",
+			}
+			fmt.Fprintf(g.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+			_, err := cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			snapPath, err := snapshot.Unpack(snapprocName)
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			cmdline = []string{
+				filepath.Join(binariesPath, "knit"),
+				"cpuaff",
+				"-P",
+				filepath.Join(snapPath, "proc"),
+			}
+
+			cmd = exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+			// it's hard to predict the actual output, so we don't try yet.
+			out, err := cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+			// but we expect _some_ output!
+			o.Expect(out).ToNot(o.BeEmpty())
+
+			cmdline = []string{
+				filepath.Join(binariesPath, "cpulist"),
+				"-P",
+				filepath.Join(snapPath, "proc"),
+				"-p",
+				"1", // this is the pid most likely to be present
+			}
+
+			cmd = exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+			// it's hard to predict the actual cpuset, so we don't try yet.
+			_, err = cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Add new command to take a snapshot of /proc.
We copy only the minimal set of files we care about to run the `cpuaff`
command.

Signed-off-by: Francesco Romani <fromani@redhat.com>