### PR TITLE
add 'cpulist' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,16 @@ all: dist
 .PHONY: build
 build: dist
 
+# legacy CI entry point
 .PHONY: ci-job
-ci-job: test-e2e-knit
+ci-job: test-e2e
+
+# new CI entry points
+.PHONY: ci-job-e2e
+ci-job-e2e: test-e2e
+
+.PHONY: ci-job-unit
+ci-job-unit: test-unit
 
 outdir:
 	mkdir -p _output || :
@@ -51,6 +59,6 @@ test-unit: test-unit-pkg
 test-unit-pkg:
 	go test ./pkg/...
 
-.PHONY: test-e2e-knit
-test-e2e-knit: binaries
+.PHONY: test-e2e
+test-e2e: binaries
 	ginkgo test/e2e

--- a/cmd/cpulist/README.md
+++ b/cmd/cpulist/README.md
@@ -1,0 +1,27 @@
+## cpulist
+
+```bash
+$ cpulist  # output varies depending on the machine
+0
+1
+2
+3
+$ cpulist -c '0,2-4,7'
+0
+2
+3
+4
+7
+$ for CPU in $( cpulist -c '0,2-4,7' ); do echo "considering CPU=${CPU}"; done
+considering CPU=0
+considering CPU=2
+considering CPU=3
+considering CPU=4
+considering CPU=7
+$ echo "0-4" | ./_output/cpulist -f -
+0
+1
+2
+3
+4
+```

--- a/cmd/cpulist/main.go
+++ b/cmd/cpulist/main.go
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ */
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+
+	"github.com/openshift-kni/debug-tools/pkg/procs"
+)
+
+func main() {
+	var procfsRoot = flag.StringP("procfs", "P", "/proc", "procfs root")
+	var cpuList = flag.StringP("cpu-list", "c", "", "cpulist to split")
+	var srcFile = flag.StringP("from-file", "f", "", "read the cpulist to split from the given file")
+	flag.Parse()
+
+	var cpus cpuset.CPUSet
+
+	if *srcFile != "" {
+		var err error
+		var data []byte
+		if *srcFile == "-" {
+			data, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			data, err = ioutil.ReadFile(*srcFile)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading cpulist from %q: %v\n", *srcFile, err)
+			os.Exit(2)
+		}
+		cpus = parseCPUsOrDie(strings.TrimSpace(string(data)))
+	} else if *cpuList != "" {
+		cpus = parseCPUsOrDie(*cpuList)
+	} else {
+		cpus = allowedCPUsOrDie(*procfsRoot)
+	}
+	printCPUList(cpus)
+}
+
+func parseCPUsOrDie(cpuList string) cpuset.CPUSet {
+	cpus, err := cpuset.Parse(cpuList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing %q: %v\n", cpuList, err)
+		os.Exit(2)
+	}
+	return cpus
+}
+
+func allowedCPUsOrDie(procfsRoot string) cpuset.CPUSet {
+	nullLog := log.New(ioutil.Discard, "", 0)
+	ph := procs.New(nullLog, procfsRoot)
+	info, err := ph.FromPID(0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading process status for pid self: %v\n", err)
+		os.Exit(4)
+	}
+	// consolidate all the cpus:
+	b := cpuset.NewBuilder()
+	for _, tidInfo := range info.TIDs {
+		for _, cpuId := range tidInfo.Affinity {
+			b.Add(cpuId)
+		}
+	}
+	return b.Result()
+}
+
+func printCPUList(cpus cpuset.CPUSet) {
+	for _, cpu := range cpus.ToSlice() {
+		fmt.Printf("%v\n", cpu)
+	}
+}

--- a/pkg/procs/info.go
+++ b/pkg/procs/info.go
@@ -97,7 +97,7 @@ func (handler *Handler) FromPID(pid int) (PIDInfo, error) {
 		handler.log.Printf("Error reading process name for pid %d: %v", pid, err)
 	}
 
-	tasksDir := filepath.Join(handler.procfsRoot, fmt.Sprintf("%d", pid), "task")
+	tasksDir := filepath.Join(handler.procfsRoot, procEntry(pid), "task")
 	tidEntries, err := handler.fs.ReadDir(tasksDir)
 	if err != nil {
 		handler.log.Printf("Error reading the tasks %q for %d: %v", tasksDir, pid, err)
@@ -157,7 +157,7 @@ func (handler *Handler) parseProcStatus(path string) (TIDInfo, error) {
 }
 
 func (handler *Handler) readProcessName(pid int) (string, error) {
-	data, err := handler.fs.ReadFile(filepath.Join(handler.procfsRoot, fmt.Sprintf("%d", pid), "cmdline"))
+	data, err := handler.fs.ReadFile(filepath.Join(handler.procfsRoot, procEntry(pid), "cmdline"))
 	if err != nil {
 		return "", err
 	}
@@ -179,4 +179,11 @@ func fixFilename(filename string) string {
 		return ""
 	}
 	return strings.Trim(name, "\x00")
+}
+
+func procEntry(pid int) string {
+	if pid == 0 {
+		return "self"
+	}
+	return fmt.Sprintf("%d", pid)
 }

--- a/test/e2e/cpulist_test.go
+++ b/test/e2e/cpulist_test.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+)
+
+var _ = g.Describe("cpulist", func() {
+	g.Context("with arguments", func() {
+		g.It("parses correctly commandline", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "cpulist"),
+				"-c",
+				"0-3,5,7-9",
+			}
+			fmt.Fprintf(g.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+
+			out, err := cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			expected := strings.Join([]string{"0", "1", "2", "3", "5", "7", "8", "9", ""}, "\n")
+
+			o.Expect(string(out)).To(o.Equal(expected))
+		})
+		g.It("parses correctly stdin", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "cpulist"),
+				"-f",
+				"-",
+			}
+			fmt.Fprintf(g.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+			cmd.Stdin = bytes.NewBufferString("0-5,7,9,12-15")
+
+			out, err := cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			expected := strings.Join([]string{"0", "1", "2", "3", "4", "5", "7", "9", "12", "13", "14", "15", ""}, "\n")
+
+			o.Expect(string(out)).To(o.Equal(expected))
+		})
+	})
+
+	g.Context("without arguments", func() {
+		g.It("parses correctly /proc/self/status", func() {
+			rootDir, err := ioutil.TempDir("", "test")
+			if err != nil {
+				g.Fail(fmt.Sprintf("creating temp dir %v", err))
+			}
+			defer os.RemoveAll(rootDir) // clean up
+
+			procDir := filepath.Join(rootDir, "proc")
+			procSelfTaskDir := filepath.Join(procDir, "self", "task", "self")
+			if err := os.MkdirAll(procSelfTaskDir, 0755); err != nil {
+				g.Fail(fmt.Sprintf("Mkdir(%s) failed: %v", procSelfTaskDir, err))
+			}
+			if err := ioutil.WriteFile(filepath.Join(procSelfTaskDir, "status"), []byte(fakeSelfStatus), 0644); err != nil {
+				g.Fail(fmt.Sprintf("WriteFile failed: %v", err))
+			}
+
+			cmdline := []string{
+				filepath.Join(binariesPath, "cpulist"),
+				"-P",
+				procDir,
+			}
+			fmt.Fprintf(g.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+
+			out, err := cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			expected := strings.Join([]string{"0", "1", "2", "3", ""}, "\n")
+
+			o.Expect(string(out)).To(o.Equal(expected))
+		})
+
+	})
+})
+
+const fakeSelfStatus string = `Name:	test
+Umask:	0000
+State:	S (sleeping)
+Tgid:	1
+Ngid:	0
+Pid:	1
+PPid:	0
+TracerPid:	0
+Uid:	0	0	0	0
+Gid:	0	0	0	0
+FDSize:	256
+Groups:	 
+NStgid:	1
+NSpid:	1
+NSpgid:	1
+NSsid:	1
+VmPeak:	  240812 kB
+VmSize:	  175276 kB
+VmLck:	       0 kB
+VmPin:	       0 kB
+VmHWM:	   17484 kB
+VmRSS:	    9084 kB
+RssAnon:	    3664 kB
+RssFile:	    5420 kB
+RssShmem:	       0 kB
+VmData:	   22448 kB
+VmStk:	     132 kB
+VmExe:	     852 kB
+VmLib:	   11292 kB
+VmPTE:	     108 kB
+VmSwap:	    2564 kB
+HugetlbPages:	       0 kB
+CoreDumping:	0
+THP_enabled:	1
+Threads:	1
+SigQ:	1/63354
+SigPnd:	0000000000000000
+ShdPnd:	0000000000000000
+SigBlk:	7be3c0fe28014a03
+SigIgn:	0000000000001000
+SigCgt:	00000001800004ec
+CapInh:	0000000000000000
+CapPrm:	000001ffffffffff
+CapEff:	000001ffffffffff
+CapBnd:	000001ffffffffff
+CapAmb:	0000000000000000
+NoNewPrivs:	0
+Seccomp:	0
+Seccomp_filters:	0
+Cpus_allowed:	f
+Cpus_allowed_list:	0-3
+Mems_allowed:	00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000000,00000001
+Mems_allowed_list:	0
+voluntary_ctxt_switches:	6498
+nonvoluntary_ctxt_switches:	1369`

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,4 +1,4 @@
-package e2eknit
+package e2e
 
 import (
 	"encoding/json"

--- a/test/e2e/knit_irqaff_test.go
+++ b/test/e2e/knit_irqaff_test.go
@@ -1,4 +1,4 @@
-package e2eknit
+package e2e
 
 import (
 	"fmt"

--- a/test/e2e/knit_irqwatch_test.go
+++ b/test/e2e/knit_irqwatch_test.go
@@ -1,4 +1,4 @@
-package e2eknit
+package e2e
 
 import (
 	"encoding/json"

--- a/test/e2e/knit_podres_test.go
+++ b/test/e2e/knit_podres_test.go
@@ -1,4 +1,4 @@
-package e2eknit
+package e2e
 
 import (
 	"fmt"


### PR DESCRIPTION
`cpulist` is meant to be a trivial frontend to the `cpuset` package,
kinda following the old unix tradition of having utilities wrapping syscalls.
Is meant to be used as helper in the validation/test scripts.

See `cmd/cpulist/README.md` for examples.

Signed-off-by: Francesco Romani <fromani@redhat.com>