### PR TITLE
pkg: move k8s dependent command in a subpackage

### DIFF
--- a/cmd/knit/main.go
+++ b/cmd/knit/main.go
@@ -21,10 +21,14 @@ import (
 	"os"
 
 	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s"
 )
 
 func main() {
-	if err := cmd.NewRootCommand().Execute(); err != nil {
+	root := cmd.NewRootCommand(
+		k8s.NewPodResourcesCommand,
+	)
+	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/pkg/knit/cmd/k8s/podres.go
+++ b/pkg/knit/cmd/k8s/podres.go
@@ -14,7 +14,7 @@
  * Copyright 2020 Red Hat, Inc.
  */
 
-package cmd
+package k8s
 
 import (
 	"context"
@@ -27,6 +27,8 @@ import (
 
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
+
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
 )
 
 // see k/k/test/e2e_node/util.go
@@ -47,7 +49,7 @@ type podResOptions struct {
 	socketPath string
 }
 
-func NewPodResourcesCommand(knitOpts *KnitOptions) *cobra.Command {
+func NewPodResourcesCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
 	opts := &podResOptions{}
 	podRes := &cobra.Command{
 		Use:   "podres",

--- a/pkg/knit/cmd/root.go
+++ b/pkg/knit/cmd/root.go
@@ -83,7 +83,6 @@ func NewRootCommand(extraCmds ...NewCommandFunc) *cobra.Command {
 		NewCPUAffinityCommand(knitOpts),
 		NewIRQAffinityCommand(knitOpts),
 		NewIRQWatchCommand(knitOpts),
-		NewPodResourcesCommand(knitOpts),
 		NewWaitCommand(knitOpts),
 	)
 	for _, extraCmd := range extraCmds {


### PR DESCRIPTION
Since the `podres` pkg pulls in ~32M of deps, bringing
the total executable size to a shopping 40M, push the offending command
in a subpacakge and link it from the client code.

This way, code willing to use the core knit functionality doesn't have
to pay the full price anyway

Signed-off-by: Francesco Romani <fromani@redhat.com>