### PR TITLE
podres: add extra helper to get the available cpus

### DIFF
--- a/pkg/knit/cmd/k8s/podres.go
+++ b/pkg/knit/cmd/k8s/podres.go
@@ -27,6 +27,7 @@ import (
 
 	kubeletpodresourcesv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
 )
@@ -43,6 +44,8 @@ const (
 const (
 	apiCallList           = "list"
 	apiCallGetAllocatable = "get-allocatable"
+
+	actionGetAvailableCPUs = "_get-available-cpus"
 )
 
 type podResOptions struct {
@@ -63,9 +66,29 @@ func NewPodResourcesCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
 	return podRes
 }
 
+func showAvailableCPUs(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
+	allocResp, err := cli.GetAllocatableResources(context.TODO(), &kubeletpodresourcesv1.AllocatableResourcesRequest{})
+	if err != nil {
+		return err
+	}
+	listResp, err := cli.List(context.TODO(), &kubeletpodresourcesv1.ListPodResourcesRequest{})
+	if err != nil {
+		return err
+	}
+	availCpus := cpuset.NewCPUSetInt64(allocResp.CpuIds...)
+	for _, podRes := range listResp.GetPodResources() {
+		for _, cntRes := range podRes.GetContainers() {
+			cntCpus := cpuset.NewCPUSetInt64(cntRes.CpuIds...)
+			availCpus = availCpus.Difference(cntCpus)
+		}
+	}
+	fmt.Printf("%v\n", availCpus.ToSlice())
+	return nil
+}
+
 // we use spew to avoid artifacts due to JSON mashalling. We want to see all the fields.
-func selectAction(apiName string) (func(cli kubeletpodresourcesv1.PodResourcesListerClient) error, error) {
-	if apiName == apiCallList {
+func selectAction(actionName string) (func(cli kubeletpodresourcesv1.PodResourcesListerClient) error, error) {
+	if actionName == apiCallList {
 		return func(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
 			resp, err := cli.List(context.TODO(), &kubeletpodresourcesv1.ListPodResourcesRequest{})
 			if err != nil {
@@ -75,7 +98,7 @@ func selectAction(apiName string) (func(cli kubeletpodresourcesv1.PodResourcesLi
 			return nil
 		}, nil
 	}
-	if apiName == apiCallGetAllocatable {
+	if actionName == apiCallGetAllocatable {
 		return func(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
 			resp, err := cli.GetAllocatableResources(context.TODO(), &kubeletpodresourcesv1.AllocatableResourcesRequest{})
 			if err != nil {
@@ -85,18 +108,21 @@ func selectAction(apiName string) (func(cli kubeletpodresourcesv1.PodResourcesLi
 			return nil
 		}, nil
 	}
+	if actionName == actionGetAvailableCPUs {
+		return showAvailableCPUs, nil
+	}
 	return func(cli kubeletpodresourcesv1.PodResourcesListerClient) error {
 		return nil
-	}, fmt.Errorf("unknown API %q", apiName)
+	}, fmt.Errorf("unknown API %q", actionName)
 }
 
 func showPodResources(cmd *cobra.Command, opts *podResOptions, args []string) error {
-	apiName := "list"
+	actionName := "list"
 	if len(args) == 1 {
-		apiName = args[0]
+		actionName = args[0]
 	}
 
-	action, err := selectAction(apiName)
+	action, err := selectAction(actionName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
the new action is prefixed with `_` because we are not really
consuming an API, and the leading underscore emphasizes this fact.

A podresources API extension is in progress to make this supported
by the kubelet.

Signed-off-by: Francesco Romani <fromani@redhat.com>