### PR TITLE
go.mod: explicit kube deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	k8s.io/klog/v2 v2.9.0
-	k8s.io/kubelet v0.0.0
-	k8s.io/kubernetes v0.0.0-00010101000000-000000000000
+	k8s.io/kubelet v0.22.2
+	k8s.io/kubernetes v0.22.2
 )
 
 // Pinned to kubernetes-1.22.2


### PR DESCRIPTION
Let's make the go.mod tidier by requiring explicitely
the kube deps. Even if they are going to be replaced anyway,
this should help `go get`.

Signed-off-by: Francesco Romani <fromani@redhat.com>