### PR TITLE
ethtool: add replacement for ethtool -k and -l

### DIFF
--- a/cmd/knit/main.go
+++ b/cmd/knit/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd/ethtool"
 	"github.com/openshift-kni/debug-tools/pkg/knit/cmd/ghw"
 	"github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s"
 	"github.com/openshift-kni/debug-tools/pkg/knit/cmd/machineinfo"
@@ -33,6 +34,7 @@ func main() {
 		ghw.NewLspciCommand,
 		ghw.NewLstopoCommand,
 		machineinfo.NewMachineInfoCommand,
+		ethtool.NewEthtoolCommand,
 	)
 	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jaypipes/ghw v0.8.1-0.20210605191321-eb162add542b
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
+	github.com/safchain/ethtool v0.2.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	k8s.io/klog/v2 v2.30.0

--- a/go.sum
+++ b/go.sum
@@ -518,6 +518,8 @@ github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021/go.mod h1:DM5xW0nvf
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/safchain/ethtool v0.2.0 h1:dILxMBqDnQfX192cCAPjZr9v2IgVXeElHPy435Z/IdE=
+github.com/safchain/ethtool v0.2.0/go.mod h1:WkKB1DnNtvsMlDmQ50sgwowDJV/hGbJSOvJoEXs1AJQ=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -830,6 +832,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e h1:XMgFehsDnnLGtjvjOfqWSUzt0alpTR1RSEuznObga2c=
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/knit/cmd/ethtool/ethtool.go
+++ b/pkg/knit/cmd/ethtool/ethtool.go
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+
+package ethtool
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	goethtool "github.com/safchain/ethtool"
+)
+
+type ethtoolOptions struct {
+	showFeatures bool
+	showChannels bool
+}
+
+func NewEthtoolCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
+	opts := &ethtoolOptions{}
+	eInfo := &cobra.Command{
+		Use:   "ethtool",
+		Short: "subset of ethtool query capabilities",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return showEthtool(cmd, knitOpts, opts, args)
+		},
+		Args: cobra.MaximumNArgs(1),
+	}
+	eInfo.Flags().BoolVarP(&opts.showFeatures, "show-features", "k", false, "show the features of the selected devices")
+	eInfo.Flags().BoolVarP(&opts.showChannels, "show-channels", "l", false, "show the channels of the selected devices")
+	return eInfo
+}
+
+func showEthtool(cmd *cobra.Command, knitOpts *cmd.KnitOptions, opts *ethtoolOptions, args []string) error {
+	var err error
+	ifaces := args
+	if len(ifaces) == 0 {
+		ifaces, err = getAllInterfaceNames()
+	}
+	if err != nil {
+		return err
+	}
+
+	needSeparator := false
+	if len(ifaces) > 1 {
+		needSeparator = true
+	}
+
+	ethHandle, err := goethtool.NewEthtool()
+	if err != nil {
+		return err
+	}
+	defer ethHandle.Close()
+
+	for _, iface := range ifaces {
+		if opts.showFeatures {
+			if err := showEthtoolFeatures(ethHandle, iface, knitOpts.JsonOutput); err != nil {
+				return err
+			}
+		}
+		if opts.showChannels {
+			if err := showEthtoolChannels(ethHandle, iface, knitOpts.JsonOutput); err != nil {
+				return err
+			}
+		}
+		if needSeparator {
+			fmt.Printf("\n")
+		}
+	}
+	return nil
+}
+
+func showEthtoolFeatures(et *goethtool.Ethtool, iface string, jsonMode bool) error {
+	feats, err := et.Features(iface)
+	if err != nil {
+		return err
+	}
+	if jsonMode {
+		json.NewEncoder(os.Stdout).Encode(feats)
+		return nil
+	}
+	fmt.Printf("Features for %s:\n", iface)
+	for key, val := range feats {
+		fmt.Printf("%s: %s\n", key, toggle(val))
+	}
+	return nil
+}
+
+func showEthtoolChannels(et *goethtool.Ethtool, iface string, jsonMode bool) error {
+	chans, err := et.GetChannels(iface)
+	if err != nil {
+		return err
+	}
+	if jsonMode {
+		json.NewEncoder(os.Stdout).Encode(chans)
+		return nil
+	}
+	fmt.Printf("Channel parameters for %s:\n", iface)
+	fmt.Printf("Pre-set maximums:\n")
+	fmt.Printf("RX:		%d\n", chans.MaxRx)
+	fmt.Printf("TX:		%d\n", chans.MaxTx)
+	fmt.Printf("Other:		%d\n", chans.MaxOther)
+	fmt.Printf("Combined:	%d\n", chans.MaxCombined)
+	fmt.Printf("Current hardware settings:\n")
+	fmt.Printf("RX:		%d\n", chans.RxCount)
+	fmt.Printf("TX:		%d\n", chans.TxCount)
+	fmt.Printf("Other:		%d\n", chans.OtherCount)
+	fmt.Printf("Combined:	%d\n", chans.CombinedCount)
+	return nil
+}
+
+func toggle(v bool) string {
+	if v {
+		return "on"
+	}
+	return "off"
+}
+
+func getAllInterfaceNames() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, iface := range ifaces {
+		if (iface.Flags & net.FlagUp) != net.FlagUp {
+			continue
+		}
+		if (iface.Flags & net.FlagLoopback) == net.FlagLoopback {
+			continue
+		}
+		names = append(names, iface.Name)
+	}
+	return names, nil
+}

--- a/test/e2e/knit_ethtool_test.go
+++ b/test/e2e/knit_ethtool_test.go
@@ -1,0 +1,51 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo"
+	o "github.com/onsi/gomega"
+)
+
+var _ = g.Describe("knit ethtool tests", func() {
+	g.Context("With loopback interface", func() {
+		g.It("should report the interface features", func() {
+			cmdline := []string{
+				filepath.Join(binariesPath, "knit"),
+				"-J",
+				"ethtool",
+				"-k",
+				"lo",
+			}
+			fmt.Fprintf(g.GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Stderr = g.GinkgoWriter
+
+			out, err := cmd.Output()
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			var features map[string]bool
+			if err := json.Unmarshal(out, &features); err != nil {
+				g.Fail("failed to unmarshal JSON data")
+			}
+			o.Expect(features).ToNot(o.BeEmpty())
+
+			countEnabled := 0
+			countDisabled := 0
+			for _, enabled := range features {
+				if enabled {
+					countEnabled++
+				} else {
+					countDisabled++
+				}
+			}
+
+			o.Expect(countEnabled).ToNot(o.BeZero(), "no enabled features for loopback")
+			o.Expect(countDisabled).ToNot(o.BeZero(), "no disabled features for loopback")
+		})
+	})
+})


### PR DESCRIPTION
Add commands to act as simple replacement for `ethtool -l` and `ethtool -k`.

even though very recent linux kernel implemented a new and more capable netlink interface to query the ethernet properties,
we intentionally consume a ioctl-based package because:

1. ioctl capabilities are fine for our use case  (we don't need more modern and powerful features  enabled by netlink just yet)
2. we maximize the backward compatibility
3. netlink-based packages are less mature
