### PR TITLE
podinfo: Try first in-cluster to get kubeconfig

### DIFF
--- a/pkg/knit/cmd/k8s/podinfo.go
+++ b/pkg/knit/cmd/k8s/podinfo.go
@@ -119,13 +119,15 @@ func NewPodInfoCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
 	return podInfo
 }
 
-// GetConfig creates a *rest.Config for talking to a Kubernetes apiserver.
+// getKubeConfig creates a *rest.Config for talking to a Kubernetes apiserver.
 //
-// Config precedence
-//
+// Config precedence:
 // - KUBECONFIG environment variable pointing at a file
-// - $HOME/.kube/config if exists
 // - In-cluster config if running in cluster
+// - $HOME/.kube/config if exists
+//
+// note: Use same precedence as controller-runtime GetConfig.
+// see: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/client/config#GetConfig
 func getKubeConfig() (*rest.Config, error) {
 	kubeconfigFromFilePath := func(kubeConfigFilePath string) (*rest.Config, error) {
 		if _, err := os.Stat(kubeConfigFilePath); err != nil {
@@ -140,15 +142,15 @@ func getKubeConfig() (*rest.Config, error) {
 		return kubeconfigFromFilePath(kubeConfig)
 	}
 
+	// try the in-cluster config
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+
 	// try the default location in the user's home directory
 	if usr, err := user.Current(); err == nil {
 		kubeConfig := filepath.Join(usr.HomeDir, ".kube", "config")
 		return kubeconfigFromFilePath(kubeConfig)
-	}
-
-	// try the in-cluster config
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
 	}
 
 	return nil, fmt.Errorf("could not locate a kubeconfig")


### PR DESCRIPTION
In order to get a kubeconfig to talk to a server API in podinfo command
three elements are tried
- KUBECONFIG env variable
- ~/.kube/config
- in-cluster config

Better to check "in-cluster config" before the one in the user home to
avoid conflicts.

pod-info command info: #64 