### PR TITLE
podinfo: Solve error in podinfo template

### DIFF
--- a/pkg/knit/cmd/k8s/podinfo.go
+++ b/pkg/knit/cmd/k8s/podinfo.go
@@ -73,9 +73,11 @@ const defaultTemplate string = `
 					"limits": {
 						"cpu": "{{.Resources.Limits.Cpu}}"
 					}
-					{{- end }}{{end}}
-					{{- if .Resources.Requests}}{{if .Resources.Requests.Cpu -}}
+					{{- end -}}{{end}}
+					{{- if and .Resources.Requests .Resources.Limits .Resources.Requests.Cpu .Resources.Limits.Cpu -}}
 					,
+					{{- end -}}
+					{{- if .Resources.Requests}}{{if .Resources.Requests.Cpu }}
 					"requests": {
 						"cpu": "{{.Resources.Requests.Cpu}}"
 					}


### PR DESCRIPTION
When some pod has "requests" but not "limits" a comma appears before the
"resource" label making the json wrong formatted.

pod-info command info: #64 