### PR TITLE
pfpstatus: record: fix edge condition

### DIFF
--- a/pkg/pfpstatus/record/recorder.go
+++ b/pkg/pfpstatus/record/recorder.go
@@ -194,11 +194,14 @@ func (rr *Recorder) Push(st podfingerprint.Status) error {
 	if st.NodeName == "" {
 		return ErrMissingNode
 	}
-	if len(rr.nodes) >= rr.maxNodes {
-		return ErrTooManyNodes
-	}
+
 	var err error
 	nr, ok := rr.nodes[st.NodeName]
+
+	if !ok && rr.maxCapacityReached() {
+		return ErrTooManyNodes
+	}
+
 	if !ok {
 		nr, err = NewNodeRecorder(st.NodeName, rr.nodeCapacity, rr.timestamper)
 		if err != nil {
@@ -226,4 +229,8 @@ func (rr *Recorder) ContentForNode(nodeName string) ([]RecordedStatus, bool) {
 		return []RecordedStatus{}, false
 	}
 	return nr.Content(), true
+}
+
+func (rr *Recorder) maxCapacityReached() bool {
+	return len(rr.nodes) >= rr.maxNodes
 }

--- a/pkg/pfpstatus/record/recorder_test.go
+++ b/pkg/pfpstatus/record/recorder_test.go
@@ -353,3 +353,43 @@ func TestRecorderPushMultipleNodesContentUnknownForNode(t *testing.T) {
 		t.Fatalf("unexpected status count for %q", "node-99")
 	}
 }
+
+func TestRecorderMultiPushSingleNode(t *testing.T) {
+	rr, err := NewRecorder(1, 5, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		if err := rr.Push(podfingerprint.Status{
+			NodeName: "node-0",
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if rr.CountNodes() != 1 {
+		t.Fatalf("unexpected node count")
+	}
+	if rr.CountRecords("node-0") != 5 {
+		t.Fatalf("unexpected status count for %q", "node-0")
+	}
+}
+
+func TestRecorderMultiPushMultipleNodes(t *testing.T) {
+	rr, err := NewRecorder(2, 5, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if err := rr.Push(podfingerprint.Status{
+			NodeName: fmt.Sprintf("node-%d", i%2),
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if rr.CountNodes() != 2 {
+		t.Fatalf("unexpected node count")
+	}
+	if rr.CountRecords("node-0") != 5 {
+		t.Fatalf("unexpected status count for %q", "node-0")
+	}
+}


### PR DESCRIPTION
currently this fails to push additional statuses to existing nodes when the capacity of the the recorder is full. Ensure this condition pass for existing nodeRecorders and is only limiting for new nodes.