### PR TITLE
pfp: recorder: support coalescing option

### DIFF
--- a/pkg/pfpstatus/pfpstatus.go
+++ b/pkg/pfpstatus/pfpstatus.go
@@ -45,9 +45,10 @@ const (
 )
 
 type StorageParams struct {
-	Enabled   bool
-	Directory string
-	Period    time.Duration
+	Enabled       bool
+	Directory     string
+	Period       time.Duration
+	CoalesceLast bool
 }
 
 type Params struct {
@@ -63,9 +64,10 @@ type environ struct {
 func DefaultParams() Params {
 	return Params{
 		Storage: StorageParams{
-			Enabled:   false,
-			Directory: DefaultDumpDirectory,
-			Period:    10 * time.Second,
+			Enabled:      false,
+			Directory:    DefaultDumpDirectory,
+			Period:       10 * time.Second,
+			CoalesceLast: false,
 		},
 	}
 }
@@ -95,7 +97,7 @@ func Setup(logh logr.Logger, params Params) {
 
 	logh.Info("Setup in progress", "params", fmt.Sprintf("%+#v", params))
 
-	rec, err := record.NewRecorder(defaultMaxNodes, defaultMaxSamplesPerNode, time.Now)
+	rec, err := record.NewRecorder(defaultMaxNodes, defaultMaxSamplesPerNode, time.Now, record.WithCoalescingRecorder(params.Storage.CoalesceLast))
 	if err != nil {
 		logh.Error(err, "cannot create a status recorder")
 		return


### PR DESCRIPTION
Support new option that if set to true it would configure the recorders to push PFP statuses only if they are unique in PFP values, otherwise it just updates the RecordTime of the last recorder status. Note that this option works only for the last recorded status and it does not affect other statuses in the stack.