### PR TITLE
pfp: recorder: add `maxSize` and `coalescing` options

### DIFF
--- a/pkg/pfpstatus/pfpstatus.go
+++ b/pkg/pfpstatus/pfpstatus.go
@@ -45,9 +45,10 @@ const (
 )
 
 type StorageParams struct {
-	Enabled   bool
-	Directory string
-	Period    time.Duration
+	Enabled      bool
+	Directory    string
+	Period       time.Duration
+	CoalesceLast bool
 }
 
 type Params struct {
@@ -63,9 +64,10 @@ type environ struct {
 func DefaultParams() Params {
 	return Params{
 		Storage: StorageParams{
-			Enabled:   false,
-			Directory: DefaultDumpDirectory,
-			Period:    10 * time.Second,
+			Enabled:      false,
+			Directory:    DefaultDumpDirectory,
+			Period:       10 * time.Second,
+			CoalesceLast: false,
 		},
 	}
 }
@@ -95,7 +97,11 @@ func Setup(logh logr.Logger, params Params) {
 
 	logh.Info("Setup in progress", "params", fmt.Sprintf("%+#v", params))
 
-	rec, err := record.NewRecorder(record.WithMaxNodes(defaultMaxNodes), record.WithNodeCapacity(defaultMaxSamplesPerNode))
+	rec, err := record.NewRecorder(
+		record.WithMaxNodes(defaultMaxNodes),
+		record.WithNodeCapacity(defaultMaxSamplesPerNode),
+		record.WithPFPCoalescing(params.Storage.CoalesceLast),
+	)
 	if err != nil {
 		logh.Error(err, "cannot create a status recorder")
 		return

--- a/pkg/pfpstatus/pfpstatus.go
+++ b/pkg/pfpstatus/pfpstatus.go
@@ -41,14 +41,16 @@ const (
 const (
 	defaultMaxNodes          = 5000
 	defaultMaxSamplesPerNode = 10
+	defaultMaxSizePerNode    = 0 // no constraints
 	defaultDumpPeriod        = 10 * time.Second
 )
 
 type StorageParams struct {
-	Enabled      bool
-	Directory    string
-	Period       time.Duration
-	CoalesceLast bool
+	Enabled        bool
+	Directory      string
+	Period         time.Duration
+	CoalesceLast   bool
+	MaxSizePerNode int
 }
 
 type Params struct {
@@ -64,10 +66,11 @@ type environ struct {
 func DefaultParams() Params {
 	return Params{
 		Storage: StorageParams{
-			Enabled:      false,
-			Directory:    DefaultDumpDirectory,
-			Period:       10 * time.Second,
-			CoalesceLast: false,
+			Enabled:        false,
+			Directory:      DefaultDumpDirectory,
+			Period:         10 * time.Second,
+			CoalesceLast:   false,
+			MaxSizePerNode: defaultMaxSizePerNode,
 		},
 	}
 }
@@ -100,6 +103,7 @@ func Setup(logh logr.Logger, params Params) {
 	rec, err := record.NewRecorder(
 		record.WithMaxNodes(defaultMaxNodes),
 		record.WithNodeCapacity(defaultMaxSamplesPerNode),
+		record.WithMaxSizePerNode(defaultMaxSizePerNode),
 		record.WithPFPCoalescing(params.Storage.CoalesceLast),
 	)
 	if err != nil {

--- a/pkg/pfpstatus/record/options.go
+++ b/pkg/pfpstatus/record/options.go
@@ -44,6 +44,12 @@ func WithPFPCoalescing(val bool) Option {
 	}
 }
 
+func WithMaxSizePerNode(maxSize int) Option {
+	return func(rr *Recorder) {
+		rr.maxSize = maxSize
+	}
+}
+
 type NodeOption func(*NodeRecorder)
 
 func WithCapacity(capacity int) NodeOption {
@@ -61,5 +67,11 @@ func WithTimestamper(tsr func() time.Time) NodeOption {
 func WithCoalescing(val bool) NodeOption {
 	return func(nr *NodeRecorder) {
 		nr.coalesceLast = val
+	}
+}
+
+func WithMaxSize(maxSize int) NodeOption {
+	return func(nr *NodeRecorder) {
+		nr.maxSize = maxSize
 	}
 }

--- a/pkg/pfpstatus/record/options.go
+++ b/pkg/pfpstatus/record/options.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package record
+
+import "time"
+
+type Option func(*Recorder)
+
+func WithNodeCapacity(nodeCapacity int) Option {
+	return func(rec *Recorder) {
+		rec.nodeCapacity = nodeCapacity
+	}
+}
+
+func WithNodeTimestamper(tsr func() time.Time) Option {
+	return func(rec *Recorder) {
+		rec.timestamper = tsr
+	}
+}
+
+func WithMaxNodes(maxNodes int) Option {
+	return func(rec *Recorder) {
+		rec.maxNodes = maxNodes
+	}
+}
+
+func WithPFPCoalescing(val bool) Option {
+	return func(rr *Recorder) {
+		rr.coalesceLast = val
+	}
+}
+
+type NodeOption func(*NodeRecorder)
+
+func WithCapacity(capacity int) NodeOption {
+	return func(nr *NodeRecorder) {
+		nr.capacity = capacity
+	}
+}
+
+func WithTimestamper(tsr func() time.Time) NodeOption {
+	return func(nr *NodeRecorder) {
+		nr.timestamper = tsr
+	}
+}
+
+func WithCoalescing(val bool) NodeOption {
+	return func(nr *NodeRecorder) {
+		nr.coalesceLast = val
+	}
+}

--- a/pkg/pfpstatus/record/recorder.go
+++ b/pkg/pfpstatus/record/recorder.go
@@ -59,26 +59,6 @@ type NodeRecorder struct {
 	coalesceLast bool
 }
 
-type NodeOption func(*NodeRecorder)
-
-func WithCapacity(capacity int) NodeOption {
-	return func(nr *NodeRecorder) {
-		nr.capacity = capacity
-	}
-}
-
-func WithTimestamper(tsr func() time.Time) NodeOption {
-	return func(nr *NodeRecorder) {
-		nr.timestamper = tsr
-	}
-}
-
-func WithCoalescing(val bool) NodeOption {
-	return func(nr *NodeRecorder) {
-		nr.coalesceLast = val
-	}
-}
-
 // NewNodeRecorder creates a new recorder for the given node with the given capacity.
 // The record is a ring buffer, so only the latest <capacity> Statuses are kept at any time.
 // The timestamper callback is used to mark times. Use `time.Now` if unsure.
@@ -161,7 +141,7 @@ func (nr *NodeRecorder) Cap() int {
 	return nr.capacity
 }
 
-// Content() returns a shallow copy of all the recorded statuses.
+// Content returns a shallow copy of all the recorded statuses.
 func (nr *NodeRecorder) Content() []RecordedStatus {
 	return nr.statuses
 }
@@ -179,32 +159,6 @@ type Recorder struct {
 	maxNodes     int
 	timestamper  Timestamper
 	coalesceLast bool
-}
-
-type Option func(*Recorder)
-
-func WithNodeCapacity(nodeCapacity int) Option {
-	return func(rec *Recorder) {
-		rec.nodeCapacity = nodeCapacity
-	}
-}
-
-func WithNodeTimestamper(tsr func() time.Time) Option {
-	return func(rec *Recorder) {
-		rec.timestamper = tsr
-	}
-}
-
-func WithMaxNodes(maxNodes int) Option {
-	return func(rec *Recorder) {
-		rec.maxNodes = maxNodes
-	}
-}
-
-func WithPFPCoalescing(val bool) Option {
-	return func(rr *Recorder) {
-		rr.coalesceLast = val
-	}
 }
 
 // NewRecorder creates a new recorder up to the given node count, each with the given capacity.
@@ -298,7 +252,7 @@ func (rr *Recorder) Push(st podfingerprint.Status) error {
 	return nr.Push(st)
 }
 
-// Content() returns a shallow copy of all the recorded statuses, by node name.
+// Content returns a shallow copy of all the recorded statuses, by node name.
 func (rr *Recorder) Content() map[string][]RecordedStatus {
 	ret := make(map[string][]RecordedStatus, len(rr.nodes))
 	for nodeName, nr := range rr.nodes {


### PR DESCRIPTION
Extend the recorder to be configured with 2 more options:
1. Max size of the NodeRecorder
2. Coalescing the last PFP record
see the commits for more context.